### PR TITLE
Modifying old components to use react-query

### DIFF
--- a/src/components/form.js
+++ b/src/components/form.js
@@ -73,8 +73,8 @@ function FormDivider() {
   );
 }
 
-function FormControl({ children }) {
-  return <div>{children}</div>;
+function FormItem({ children }) {
+  return <div className="form-item">{children}</div>;
 }
 
 function FormContainer({ onSubmit, children }) {
@@ -157,4 +157,4 @@ const Form = ({
   );
 };
 
-export { Form, FormDivider, FormControl, FormLink };
+export { Form, FormItem, FormDivider, FormLink };

--- a/src/components/habit-list.js
+++ b/src/components/habit-list.js
@@ -1,0 +1,98 @@
+import {
+  Box,
+  Chip,
+  IconButton,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+} from '@material-ui/core';
+import {
+  Delete as DeleteIcon,
+  Edit as EditIcon,
+  Folder as FolderIcon,
+} from '@material-ui/icons';
+import { useDialog } from 'context/dialog-context';
+import { useSnackbar } from 'context/snackbar-context';
+import { useDeleteHabit } from 'hooks/useDeleteHabit';
+import { Link as RouterLink } from 'react-router-dom';
+import { weekdays } from 'utils/misc';
+
+function HabitListItem({ habit }) {
+  const { id, name, description, frequency } = habit;
+
+  const { openSnackbar } = useSnackbar();
+  const { openDialog } = useDialog();
+
+  const [deleteHabit, { isLoading }] = useDeleteHabit();
+
+  const handleDeleteClick = async () => {
+    openDialog({
+      title: `Remove "${name}" habit?`,
+      description: `
+      Deleted habit can't be recovered. All data 
+      associated with this habit will be deleted.`,
+      confirmText: 'Delete',
+      onConfirm: () =>
+        deleteHabit(id, {
+          onSuccess: () => openSnackbar('success', 'Habit removed!'),
+          onError: () => openSnackbar('error', 'Error!'),
+        }),
+      color: 'secondary',
+    });
+  };
+
+  return (
+    <ListItem button>
+      {/* TODO: Let user choose icon */}
+      <ListItemIcon>
+        <FolderIcon />
+      </ListItemIcon>
+
+      {/* Name and description */}
+      <ListItemText primary={name} secondary={description} />
+
+      {/* Frequency */}
+      <Box mr={1}>
+        {weekdays.map((day, i) => (
+          <Chip
+            key={day}
+            label={day.slice(0, 1)}
+            color={frequency.includes(i) ? 'primary' : 'default'}
+          />
+        ))}
+      </Box>
+
+      {/* Edit link */}
+      <IconButton
+        to={`/edit-habit/${id}`}
+        component={RouterLink}
+        aria-label="Edit habit"
+        disabled={isLoading}
+      >
+        <EditIcon />
+      </IconButton>
+
+      {/* Delete button */}
+      <IconButton
+        onClick={handleDeleteClick}
+        aria-label="Delete habit"
+        disabled={isLoading}
+      >
+        <DeleteIcon />
+      </IconButton>
+    </ListItem>
+  );
+}
+
+function HabitList({ habits }) {
+  return (
+    <List>
+      {habits.map(habit => (
+        <HabitListItem key={habit.id} habit={habit} />
+      ))}
+    </List>
+  );
+}
+
+export { HabitList };

--- a/src/components/lib.js
+++ b/src/components/lib.js
@@ -23,6 +23,25 @@ function ButtonProgress(props) {
   return <LinearProgress className={classes.buttonProgress} {...props} />;
 }
 
+function ErrorMessage({ error, inline, ...props }) {
+  const display = inline ? 'inline' : 'block';
+
+  return (
+    <Box role="alert" color="error.main" display={display} {...props}>
+      <span>There was an error</span>
+      <Box
+        component="pre"
+        display={display}
+        margin={0}
+        mb={-5}
+        whiteSpace="break-spaces"
+      >
+        {error.message}
+      </Box>
+    </Box>
+  );
+}
+
 function FullPageSpinner() {
   return (
     <Box
@@ -63,4 +82,4 @@ function FullPageErrorFallback({ error }) {
   );
 }
 
-export { ButtonProgress, FullPageSpinner, FullPageErrorFallback };
+export { ButtonProgress, ErrorMessage, FullPageSpinner, FullPageErrorFallback };

--- a/src/hooks/useAddHabit.js
+++ b/src/hooks/useAddHabit.js
@@ -1,0 +1,25 @@
+import { useFirebase } from 'context/firebase-context';
+import { queryCache, useMutation } from 'react-query';
+
+export function useAddHabit() {
+  const { db } = useFirebase();
+
+  return useMutation(
+    fields => {
+      const { name, description, frequency } = fields;
+
+      const newHabitRef = db.ref('maciek/habits').push();
+
+      return newHabitRef.set({
+        // position: 0,
+        name,
+        description,
+        frequency,
+        createdAt: new Date().toISOString(),
+      });
+    },
+    {
+      onSuccess: () => queryCache.refetchQueries('habits'),
+    }
+  );
+}

--- a/src/hooks/useDeleteHabit.js
+++ b/src/hooks/useDeleteHabit.js
@@ -1,0 +1,19 @@
+import { useFirebase } from 'context/firebase-context';
+import { queryCache, useMutation } from 'react-query';
+
+export function useDeleteHabit() {
+  const { db } = useFirebase();
+
+  return useMutation(
+    habitId => {
+      const updates = {};
+
+      updates[`maciek/habits/${habitId}`] = null;
+
+      return db.ref().update(updates);
+    },
+    {
+      onSuccess: () => queryCache.refetchQueries('habits'),
+    }
+  );
+}

--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -1,0 +1,26 @@
+import { useFirebase } from 'context/firebase-context';
+import { useQuery } from 'react-query';
+
+export function useHabits() {
+  const { db } = useFirebase();
+
+  return useQuery('habits', () =>
+    db
+      .ref('maciek/habits')
+      .once('value')
+      .then(snapshot => {
+        let fetchedHabits = [];
+
+        if (snapshot.exists()) {
+          snapshot.forEach(childSnapshot => {
+            fetchedHabits.push({
+              id: childSnapshot.key,
+              ...childSnapshot.val(),
+            });
+          });
+        }
+
+        return fetchedHabits;
+      })
+  );
+}

--- a/src/screens/add-habit.js
+++ b/src/screens/add-habit.js
@@ -1,0 +1,166 @@
+import * as React from 'react';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Controller, useForm } from 'react-hook-form';
+import { Form, FormItem } from 'components/form';
+import { useSnackbar } from 'context/snackbar-context';
+import { habitSchema } from 'data/constraints';
+import { useAddHabit } from 'hooks/useAddHabit';
+import { weekdays } from 'utils/misc';
+import {
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  FormLabel,
+  makeStyles,
+  TextField,
+} from '@material-ui/core';
+
+// Styles
+const useStyles = makeStyles({
+  actions: {
+    justifyContent: 'flex-end',
+  },
+  formControl: {
+    width: '100%',
+  },
+  frequencyLabel: {
+    // 14px is a value taken from .MuiOutlinedInput-input
+    // so that the label is aligned equally to other labels
+    padding: '0 14px',
+  },
+
+  disableMargin: {
+    marginLeft: 0,
+    marginRight: 0,
+  },
+});
+
+// Initial habit
+const initialHabit = {
+  name: '',
+  description: '',
+  /**
+   * # TODO: Add more types
+   *
+   * It, should be possible, for example, to set the habit to occur
+   * every X days.
+   *
+   */
+  frequencyType: 'weekdays',
+  frequencyValue: [],
+};
+
+const AddHabitScreen = () => {
+  const classes = useStyles();
+  const { openSnackbar } = useSnackbar();
+  const [
+    addHabit,
+    { isLoading, isError: isAddingHabitError, error },
+  ] = useAddHabit();
+
+  // Form
+  const { control, register, handleSubmit, errors, getValues, reset } = useForm(
+    {
+      defaultValues: initialHabit,
+      resolver: yupResolver(habitSchema),
+    }
+  );
+  const handleCheckbox = checkedDay => {
+    const { frequencyValue: days } = getValues();
+
+    const newDays = days?.includes(checkedDay)
+      ? days?.filter(day => day !== checkedDay)
+      : [...(days ?? []), checkedDay];
+
+    return newDays;
+  };
+
+  // Submit form
+  const onSubmit = form => {
+    const { name, description, frequencyValue } = form;
+
+    addHabit(
+      { name, description, frequency: frequencyValue },
+      {
+        onSuccess: () => openSnackbar('success', 'Habit added!'),
+      }
+    );
+    reset(initialHabit);
+  };
+
+  const formErrors = Object.values(errors);
+  const isError = isAddingHabitError || formErrors.length !== 0;
+  const errorMessage = error?.message || formErrors[0]?.message;
+
+  return (
+    <Form
+      onSubmit={handleSubmit(onSubmit)}
+      primaryText="Create new habit"
+      buttonText="Create habit"
+      isLoading={isLoading}
+      isError={isError}
+      helperText={errorMessage}
+    >
+      <FormItem>
+        <TextField
+          inputRef={register}
+          name="name"
+          label="Habit name"
+          error={!!errors?.name}
+          variant="outlined"
+          disabled={isLoading}
+          fullWidth
+        />
+      </FormItem>
+
+      <FormItem>
+        <TextField
+          inputRef={register}
+          name="description"
+          label="Question (optional)"
+          error={!!errors?.description}
+          variant="outlined"
+          disabled={isLoading}
+          fullWidth
+        />
+      </FormItem>
+
+      <FormItem>
+        <FormControl
+          component="fieldset"
+          className={classes.formControl}
+          error={!!(errors && errors.frequencyValue)}
+        >
+          <FormLabel component="legend" className={classes.frequencyLabel}>
+            Frequency
+          </FormLabel>
+          <FormGroup row>
+            <Controller
+              name="frequencyValue"
+              control={control}
+              render={props =>
+                weekdays.map((name, number) => (
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        onChange={() => props.onChange(handleCheckbox(number))}
+                        checked={props.value.includes(number)}
+                      />
+                    }
+                    key={name}
+                    label={name.slice(0, 3)}
+                    labelPlacement="bottom"
+                    className={classes.disableMargin}
+                  />
+                ))
+              }
+            />
+          </FormGroup>
+        </FormControl>
+      </FormItem>
+    </Form>
+  );
+};
+
+export default AddHabitScreen;

--- a/src/screens/manage-habits.js
+++ b/src/screens/manage-habits.js
@@ -1,0 +1,21 @@
+import { Box } from '@material-ui/core';
+import { HabitList } from 'components/habit-list';
+import { FullPageSpinner } from 'components/lib';
+import { useHabits } from 'hooks/useHabits';
+import NoHabits from 'screens/no-habits';
+
+function ManageHabits() {
+  const { data: habits, isLoading } = useHabits();
+
+  if (isLoading) return <FullPageSpinner />;
+
+  if (!habits.length) return <NoHabits />;
+
+  return (
+    <Box width="100%" height="100%">
+      <HabitList habits={habits} />
+    </Box>
+  );
+}
+
+export default ManageHabits;

--- a/src/screens/no-habits.js
+++ b/src/screens/no-habits.js
@@ -1,0 +1,41 @@
+import { Add as AddIcon } from '@material-ui/icons';
+import { ReactComponent as EmptyBox } from 'images/empty-box.svg';
+import { Link as RouterLink } from 'react-router-dom';
+
+import { Fab, Box, Typography } from '@material-ui/core';
+
+function NoHabitsScreen() {
+  return (
+    <Box
+      height="100%"
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Box clone width="40%" height="40%" margin={2}>
+        <EmptyBox />
+      </Box>
+
+      <Box margin={2} textAlign="center">
+        <Typography variant="h5" gutterBottom>There are no habits</Typography>
+        <Typography variant="body1">
+          It looks like you don't have any habits yet, why don't you add one?
+        </Typography>
+      </Box>
+      <Fab
+        variant="extended"
+        color="primary"
+        component={RouterLink}
+        to="/add-habit"
+      >
+        <Box clone mr={1}>
+          <AddIcon />
+        </Box>
+        Add habit
+      </Fab>
+    </Box>
+  );
+}
+
+export default NoHabitsScreen;

--- a/src/screens/not-found.js
+++ b/src/screens/not-found.js
@@ -1,0 +1,36 @@
+import { Link as RouterLink } from 'react-router-dom';
+
+import { Fab, Box, Typography } from '@material-ui/core';
+import { Home as HomeIcon } from '@material-ui/icons';
+
+import { ReactComponent as HelloDarkness } from 'images/hello-darkness.svg';
+
+function NotFoundScreen() {
+  return (
+    <Box
+      height="100%"
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Box clone width="50%" height="50%" margin={2}>
+        <HelloDarkness />
+      </Box>
+
+      <Box margin={2}>
+        <Typography variant="h4">
+          Sorry... nothing here.
+        </Typography>
+      </Box>
+      <Fab variant="extended" color="primary" component={RouterLink} to="/dashboard">
+        <Box clone mr={1}>
+          <HomeIcon />
+        </Box>
+        Home
+      </Fab>
+    </Box>
+  );
+}
+
+export default NotFoundScreen;

--- a/src/screens/reset-password.js
+++ b/src/screens/reset-password.js
@@ -1,6 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { TextField } from '@material-ui/core';
-import { Form, FormControl, FormLink } from 'components/form';
+import { Form, FormItem, FormLink } from 'components/form';
 import { useAuth } from 'context/auth-context';
 import { useSnackbar } from 'context/snackbar-context';
 import { resetPasswordSchema } from 'data/constraints';
@@ -41,7 +41,7 @@ const SignInForm = () => {
       isError={isError}
       helperText={errorMessage}
     >
-      <FormControl>
+      <FormItem>
         <TextField
           inputRef={register}
           name="email"
@@ -53,7 +53,7 @@ const SignInForm = () => {
           variant="outlined"
           fullWidth
         />
-      </FormControl>
+      </FormItem>
     </Form>
   );
 };

--- a/src/screens/sign-in.js
+++ b/src/screens/sign-in.js
@@ -1,6 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Link, TextField } from '@material-ui/core';
-import { Form, FormControl, FormDivider, FormLink } from 'components/form';
+import { Form, FormItem, FormDivider, FormLink } from 'components/form';
 import { useAuth } from 'context/auth-context';
 import { signInSchema } from 'data/constraints';
 import { useForm } from 'react-hook-form';
@@ -43,18 +43,18 @@ const SignInForm = () => {
       isError={isError}
       helperText={errorMessage}
     >
-      <FormControl>
+      <FormItem>
         <AuthProviderList
           text="Sign in with"
           onAuthProviderClick={signInWithAuthProvider}
         />
-      </FormControl>
+      </FormItem>
 
-      <FormControl>
+      <FormItem>
         <FormDivider />
-      </FormControl>
+      </FormItem>
 
-      <FormControl>
+      <FormItem>
         <TextField
           inputRef={register}
           name="email"
@@ -66,9 +66,9 @@ const SignInForm = () => {
           variant="outlined"
           fullWidth
         />
-      </FormControl>
+      </FormItem>
 
-      <FormControl>
+      <FormItem>
         <TextField
           inputRef={register}
           name="password"
@@ -81,7 +81,7 @@ const SignInForm = () => {
           variant="outlined"
           fullWidth
         />
-      </FormControl>
+      </FormItem>
     </Form>
   );
 };

--- a/src/screens/sign-up.js
+++ b/src/screens/sign-up.js
@@ -1,6 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { TextField } from '@material-ui/core';
-import { Form, FormControl, FormDivider, FormLink } from 'components/form';
+import { Form, FormItem, FormDivider, FormLink } from 'components/form';
 import { useAuth } from 'context/auth-context';
 import { signUpSchema } from 'data/constraints';
 import { useForm } from 'react-hook-form';
@@ -38,18 +38,18 @@ function SignUpForm() {
       isError={isError}
       helperText={errorMessage}
     >
-      <FormControl>
+      <FormItem>
         <AuthProviderList
           text="Sign up with"
           onAuthProviderClick={signInWithAuthProvider}
         />
-      </FormControl>
+      </FormItem>
 
-      <FormControl>
+      <FormItem>
         <FormDivider />
-      </FormControl>
+      </FormItem>
 
-      <FormControl>
+      <FormItem>
         <TextField
           inputRef={register}
           name="email"
@@ -61,9 +61,9 @@ function SignUpForm() {
           variant="outlined"
           fullWidth
         />
-      </FormControl>
+      </FormItem>
 
-      <FormControl>
+      <FormItem>
         <TextField
           inputRef={register}
           name="password"
@@ -76,9 +76,9 @@ function SignUpForm() {
           variant="outlined"
           fullWidth
         />
-      </FormControl>
+      </FormItem>
 
-      <FormControl>
+      <FormItem>
         <TextField
           inputRef={register}
           name="passwordConfirmation"
@@ -91,7 +91,7 @@ function SignUpForm() {
           variant="outlined"
           fullWidth
         />
-      </FormControl>
+      </FormItem>
     </Form>
   );
 };

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -1,0 +1,2 @@
+// Replace with programmatic solution when working on localization
+export const weekdays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];


### PR DESCRIPTION
I'm using [react query blog example](https://github.com/tannerlinsley/react-query-blog-refactor-example) and [bookshelf](https://github.com/kentcdodds/bookshelf/tree/097849ffcf68dda53a6d15abc4ba00d351b48a6b) as reference points.

I've already finished `add-habit` and `manage-habits` routes and they're working fine. I'm now working on `edit-habit`.